### PR TITLE
Fix uvicorn run when running in debug mode

### DIFF
--- a/func_to_web/__init__.py
+++ b/func_to_web/__init__.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import inspect
 import io
@@ -478,4 +479,6 @@ def run(func_or_list, host: str="0.0.0.0", port: int=8000, template_dir: str | P
             app.get(route)(make_form_handler(func, func_name, params, submit_route))
             app.post(submit_route)(make_submit_handler(func, params))
     
-    uvicorn.run(app, host=host, port=port, reload=False)
+    config = uvicorn.Config(app, host=host, port=port, reload=False)
+    server = uvicorn.Server(config)
+    asyncio.run(server.serve())


### PR DESCRIPTION
When running it directly, no issue, but when I try to start a debug session, I've got an error when trying to debug any of the examples:
```
File "/Users/vmatt/Documents/GitHub/FuncToWeb/.venv/lib/python3.12/site-packages/uvicorn/server.py", line 67, in run 
    return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory()) 
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
TypeError: _patch_asyncio.<locals>.run() got an unexpected keyword argument 'loop_factory'  
```
_Note - I used Claude 4.5 to find and implement the fix._

The error is occurring because there's a conflict between the debugger's asyncio patching and uvicorn's loop_factory parameter. This is a known compatibility issue when running uvicorn under certain   
debuggers.
The fix is to use uvicorn.Server directly with asyncio.run() instead of uvicorn.run(), which will avoid the problematic loop_factory parameter.
This change replaces the uvicorn.run() call with a manual server setup using uvicorn.Config and uvicorn.Server, then runs it with asyncio.run(). This avoids the loop_factory parameter that's causing   
the conflict with the debugger. 
